### PR TITLE
Script and README for fixing fasta description lines

### DIFF
--- a/scripts/10_mapping/10a_gffValidation/README.md
+++ b/scripts/10_mapping/10a_gffValidation/README.md
@@ -19,3 +19,16 @@ In order for to properly count mapped reads, the GFF files must be in the proper
 * `error: could not parse score '' on line XYZ in file ‘genome.gff’`
 
   This error occurs because a line of the GFF file is incomplete (e.g., missing the score information). I found this to occur only for CRISPR arrays defined in the final line of the GFF file. Since I am not concerned with mapping to CRISPR arrays, I deleted those lines.
+
+Validation of Fasta header files
+--
+In order for to properly count mapped reads, the `seqID` field in the GFF files must match the description line in the fasta files. The script `fnaValidator` updates the fasta description to use the short form used in the `seqID` field.
+
+I don't know why the gff and fasta files from IMG have different values for this field, but they do. Briefly, the fasta files contain a description of the form:
+
+`ME10739DRAFT_MEint_metabat_10739_757002236.1 Composite genome from Lake Mendota Epilimnion pan-assembly MEint.metabat.10739 : ME10739DRAFT_MEint_metabat_10739_757002236.1`
+
+while the GFF files have a seqID of the form:
+`ME10739DRAFT_MEint_metabat_10739_757002236.1`
+
+The desired fasta description line is limited to the material after the semi-colon. The script `fnaValidator` rewrites the fasta files with the correct description line.

--- a/scripts/10_mapping/10a_gffValidation/fnaValidator.py
+++ b/scripts/10_mapping/10a_gffValidation/fnaValidator.py
@@ -1,0 +1,58 @@
+###############################################################################
+# fnaValidator.py
+# Copyright (c) 2015, Joshua J Hamilton and Katherine D McMahon
+# Affiliation: Department of Bacteriology
+#              University of Wisconsin-Madison, Madison, Wisconsin, USA
+# URL: http://http://mcmahonlab.wisc.edu/
+# All rights reserved.
+################################################################################
+# Read in fna files and update header lines.
+################################################################################
+
+#%%#############################################################################
+### Import packages
+################################################################################
+
+from Bio import SeqIO
+import os
+import pandas as pd
+import re
+
+#%%#############################################################################
+### Static folder structure
+################################################################################
+# Define fixed input and output files
+genomeFolder = '../../../data/refGenomes/fna'
+stdName = 'pFN18A_DNA_transcript'
+
+#%%#############################################################################
+### Step 0 - Read in directory lists and files needed for normalization
+################################################################################
+
+# Read in list of genomes. Ignore internal standard genome.
+genomeList = []
+for genome in os.listdir(genomeFolder):
+    if stdName in genome or 'merged' in genome or genome.startswith('.'):
+        next
+    elif genome.endswith('.fna'):
+       genomeList.append(genome)
+
+genomeList = [genome.replace('.fna', '') for genome in genomeList]
+
+#%%#############################################################################
+### Step 1 - Loop over each fna file and update the header information.
+################################################################################
+
+for genome in genomeList:
+    inFile = open(genomeFolder+'/'+genome+'.fna', 'r')
+    outFile = open(genomeFolder+'/'+genome+'.new.fna', 'w')
+
+    for record in SeqIO.parse(inFile, 'fasta'):
+        record.description = record.id
+        SeqIO.write(record, outFile, 'fasta')
+    inFile.close()
+    outFile.close()    
+
+# Delete the old file and rename the new one
+    os.remove(genomeFolder+'/'+genome+'.fna')
+    os.rename(genomeFolder+'/'+genome+'.new.fna', genomeFolder+'/'+genome+'.fna')


### PR DESCRIPTION
For some reason, gff and fasta files contain different information for the gff 'seqID' field and the fasta 'description line.' These should be identical for counting via htseq-count. When mapping with 'bwa', there are no problems with counting, but when mapping with 'BBMap', the different field values cause problems. This script makes the fields identical in the two files so you can use BBMap.
